### PR TITLE
Fixed typo

### DIFF
--- a/cairn-srd.md
+++ b/cairn-srd.md
@@ -288,7 +288,7 @@ Se vuoi qualcosa di più simile alle classi tradizionali, fai riferimento alla l
 | 1	| Antico 		| 6    | Logoro 	|
 | 2	| Insanguinato  | 7    | Sgargiante |
 | 3	| Elegante 		| 8    | Livrea 	|
-| 4	| Sporco  		| 9    | Fedito 	|
+| 4	| Sporco  		| 9    | Fetido 	|
 | 5	| Esotico 		| 10   | Sudicio 	|
 
 #### Virtù


### PR DESCRIPTION
I vestiti riportano _fedito_ come traduzione di _rancid_, _fedito_ è una parola, ma per via dell'originale la traduzione corretta dovrebbe essere **fetido**